### PR TITLE
#53 Done Rework all links between nodes

### DIFF
--- a/Src/Nodes/abstract_node.py
+++ b/Src/Nodes/abstract_node.py
@@ -16,35 +16,18 @@ class AbstractNode(ABC):
     Attributes:
         node_tag: str | int - индетификатор ноды (dpg.node)
         incoming: list[Node] - связи с нодами, которые подключенны к этой ноде. (Приходящие)
-        outcoming: list[Node] - связи с нодами, к которым подключенна эта нода. (Уходящие)
+        outgoing: list[Node] - связи с нодами, к которым подключенна эта нода. (Уходящие)
     '''
     node_tag: str | int
-    incoming: list["AbstractNode"]
-    outcoming: list["AbstractNode"]
+    # Устанавливаем связи не между узлами, а между их аттрибутами
+    incoming: dict[str | int, str | int]
+    outgoing: dict[str | int, str | int]
     annotations: dict[str, Parameter]
     logic: Callable
     docs: str
     input: bool
     output: bool
     logger: Logger
-
-
-    # TODO Переписать это говно
-    @staticmethod
-    def print_tree(node: "AbstractNode"):
-        '''
-        Метод для дебага.
-        Выводит дерево зависимостей по входящим нодам.
-
-        Args:
-            node: Node - нода с которой начинать построение.
-        '''
-        if len(node.outcoming) == 0: 
-            print(node)
-            return
-
-        print(node, "->", end=' ')
-        AbstractNode.print_tree(node.outcoming[0])
 
 
     def __init__(self, node_tag: int | str, annotations: dict[str: type], \
@@ -61,8 +44,8 @@ class AbstractNode(ABC):
         self.node_tag = node_tag
         self.annotations = annotations
         self.logic = logic
-        self.incoming = []
-        self.outcoming = []
+        self.incoming = {}
+        self.outgoing = {}
         self.input = input
         self.output = output
 
@@ -77,7 +60,9 @@ class AbstractNode(ABC):
 
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__} {self.node_tag} {dict(incoming=self.incoming, outcoming=self.outcoming)}"
+        incoming_nodes : list["AbstractNode"] = [dpg.get_item_parent(attribute) for attribute in self.incoming.values()]
+        outgoing_nodes : list["AbstractNode"] = [dpg.get_item_parent(attribute) for attribute in self.outgoing.values()]
+        return f"{self.__class__.__name__} {self.node_tag} {dict(incoming=incoming_nodes, outgoing=outgoing_nodes)}"
     
 
     def __hash__(self):
@@ -111,7 +96,7 @@ class AbstractNode(ABC):
 @dataclass
 class node_link:
     '''
-    Класс для dpg.add_node_link, указывает какие ноды связываются.
+    Класс для dpg.add_node_link, указывает какие аттрибуты узлов связываются.
     '''
-    outcoming: AbstractNode
-    incoming: AbstractNode
+    outgoing: str | int
+    incoming: str | int

--- a/Src/Nodes/layer_node.py
+++ b/Src/Nodes/layer_node.py
@@ -8,9 +8,6 @@ class LayerNode(AbstractNode):
     '''
     Класс хранящий данные, для связи нода с слоём нейроной сети.
     '''
-    incoming: list["LayerNode"]
-    outcoming: list["LayerNode"]
-
 
     def compile(self):
         self.layer: layers.Layer = super().compile()

--- a/Src/node_builder.py
+++ b/Src/node_builder.py
@@ -137,25 +137,6 @@ class NodeBuilder:
         Компиляция графа, от его концов. Работает через обход в ширину. Вызывает метод compile у нода, если все ноды, пришедшие к нему уже скомпилированы. Начинает с нодов, у которых нет входов.
         '''
 
-        # ref_node: AbstractNode = dpg.get_item_user_data(dpg.get_item_children("node_editor", slot=1)[-1])
-        # queue: list[AbstractNode] = [ref_node]
-        # visited = set()
-        # starting_nodes: list[AbstractNode] = []
-
-        # # * Двустороний обход в ширину, чтоб найти стартовые ноды
-        # while queue:
-        #     current_node = queue.pop()
-
-        #     if current_node in visited: continue
-
-        #     if len(current_node.incoming) == 0: starting_nodes.append(current_node)
-            
-        #     for neightbor in current_node.incoming + current_node.outcoming:
-        #             if neightbor not in queue:
-        #                 queue = [neightbor] + queue
-
-        #     visited.add(current_node)
-
         visited = set()
         queue = start_nodes
         self.logger.info("Началась сборка графа.")
@@ -165,13 +146,14 @@ class NodeBuilder:
             self.logger.debug(f"Текущая очередь - {queue}")
             self.logger.debug(f"Текущая нода - {current_node}")
 
-            if set(current_node.incoming) | visited == visited:
+            if set(current_node.incoming.values()) | visited == visited:
                 self.logger.debug("Нода подошла.")
 
                 layer = current_node.compile()
                 print(layer)
 
-                for neightbor in current_node.outcoming:
+                for attr_id in current_node.outgoing.values():
+                    neightbor: AbstractNode = dpg.get_item_user_data(dpg.get_item_parent(attr_id))
                     if neightbor not in queue:
                         queue = [neightbor] + queue
 


### PR DESCRIPTION
Переписал хранение связей между узлами. Теперь узлы ссылаются не друг на друга, а ссылаются их атрибуты, которые связаны друг на друга. Сделано ввиде словаря, где он каждый раз указывает, какой атрибут узла ссылается на какой аттрибут внешнего узла.

То есть у узла 1, атрибута 2, который ссылается на узел 3, атрибута 4 будет так: 1[2] = 4
а у узда 3: 3[4] = 2

И соответсвенно переписал всю логику связывания, тем самым исправив баг.