### PR TITLE
#137 Compile window

### DIFF
--- a/Assets/themes.json
+++ b/Assets/themes.json
@@ -140,6 +140,14 @@
     },
     "mvNodeAttribute": { "mvNodeCol_Pin": [255, 111, 0, 255], "mvNodeCol_Link": [255, 111, 0, 255] }
   },
+  "callback": {
+    "mvNode": {
+      "mvNodeCol_TitleBar": [255, 111, 0, 255],
+      "mvNodeCol_TitleBarHovered": [255, 130, 25, 255],
+      "mvNodeCol_TitleBarSelected": [255, 145, 51, 255]
+    },
+    "mvNodeAttribute": { "mvNodeCol_Pin": [255, 111, 0, 255], "mvNodeCol_Link": [255, 111, 0, 255] }
+  },
   "layer": {
     "mvNode": {
       "mvNodeCol_TitleBar": [66, 165, 245, 255],

--- a/Src/Config/TrainingCallbacks/__init__.py
+++ b/Src/Config/TrainingCallbacks/__init__.py
@@ -1,0 +1,1 @@
+from Src.Config.TrainingCallbacks.callbacks_list import callbacks_list

--- a/Src/Config/TrainingCallbacks/callbacks_list.py
+++ b/Src/Config/TrainingCallbacks/callbacks_list.py
@@ -1,0 +1,27 @@
+from keras import callbacks
+
+from Src.Config.TrainingCallbacks.log2window import Log2Window
+
+
+callbacks_list = {
+        "EarlyStopping": {
+            "class": callbacks.EarlyStopping,
+            "kwargs": {
+                "monitor": "loss"
+            }
+        },
+        "ReduceLROnPlateau": {
+            "class": callbacks.ReduceLROnPlateau,
+            "kwargs": {
+                "monitor": "loss"
+            }
+        },
+        "TerminateOnNaN": {
+            "class": callbacks.TerminateOnNaN,
+            "kwargs": {}
+        },
+        "Log2Window": {
+            "class": Log2Window,
+            "kwargs": {}
+        }
+    }

--- a/Src/Config/TrainingCallbacks/log2window.py
+++ b/Src/Config/TrainingCallbacks/log2window.py
@@ -1,0 +1,37 @@
+from keras import callbacks
+
+from Src.Nodes import AbstractNode
+
+
+
+class Log2Window(callbacks.Callback):
+    '''
+    Колбэк для вывода логов обучения в окно сборки модели.
+    '''
+
+    def on_train_begin(self, logs: dict | None = None):
+        '''
+        Вывод в окно сборки модели сообщения о начале обучения.
+        '''
+        AbstractNode.add_message_to_compile_window_static("Обучение начато!")
+
+
+    def on_epoch_begin(self, epoch: int, logs: dict | None = None):
+        '''
+        Вывод в окно сборки модели сообщения о начале эпохи.
+        '''
+        AbstractNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} началась...")
+
+
+    def on_epoch_end(self, epoch: int, logs: dict | None = None):
+        '''
+        Вывод в окно сборки модели сообщения о конце эпохи.
+        '''
+        AbstractNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} закончилась: {logs}")
+
+
+    def on_train_end(self, logs: dict | None = None):
+        '''
+        Вывод в окно сборки модели сообщения о конце обучения.
+        '''
+        AbstractNode.add_message_to_compile_window_static("Обучение завершено!")

--- a/Src/Config/TrainingCallbacks/log2window.py
+++ b/Src/Config/TrainingCallbacks/log2window.py
@@ -6,7 +6,7 @@ from Src.Nodes import AbstractNode
 
 class Log2Window(callbacks.Callback):
     '''
-    Колбэк для вывода логов обучения в окно сборки модели.
+    Сallback для вывода логов обучения в окно сборки модели.
     '''
 
     def on_train_begin(self, logs: dict | None = None):

--- a/Src/Config/TrainingCallbacks/log2window.py
+++ b/Src/Config/TrainingCallbacks/log2window.py
@@ -13,25 +13,25 @@ class Log2Window(callbacks.Callback):
         '''
         Вывод в окно сборки модели сообщения о начале обучения.
         '''
-        AbstractNode.add_message_to_compile_window_static("Обучение начато!")
+        AbstractNode.log2window("Обучение начато!")
 
 
     def on_epoch_begin(self, epoch: int, logs: dict | None = None):
         '''
         Вывод в окно сборки модели сообщения о начале эпохи.
         '''
-        AbstractNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} началась...")
+        AbstractNode.log2window(f"Эпоха {epoch + 1} началась...")
 
 
     def on_epoch_end(self, epoch: int, logs: dict | None = None):
         '''
         Вывод в окно сборки модели сообщения о конце эпохи.
         '''
-        AbstractNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} закончилась: {logs}")
+        AbstractNode.log2window(f"Эпоха {epoch + 1} закончилась: {logs}")
 
 
     def on_train_end(self, logs: dict | None = None):
         '''
         Вывод в окно сборки модели сообщения о конце обучения.
         '''
-        AbstractNode.add_message_to_compile_window_static("Обучение завершено!")
+        AbstractNode.log2window("Обучение завершено!")

--- a/Src/Config/node_list.py
+++ b/Src/Config/node_list.py
@@ -337,8 +337,9 @@ node_list = {
                 annotations = {
                         "x": Parameter(AttrType.INPUT, ANode[Single[DataNode]]),
                         "y": Parameter(AttrType.INPUT, ANode[Single[DataNode]]),
+                        "callbacks": Parameter(AttrType.INPUT, ANode[CallbackNode]),
                         "epochs": Parameter(AttrType.INPUT, AInteger),
-                        "history": Parameter(AttrType.OUTPUT, ANode[DataNode])  
+                        "history": Parameter(AttrType.OUTPUT, ANode[DataNode])
                     },
                 input = Single[CompileNode]
             ),
@@ -351,6 +352,15 @@ node_list = {
                     },
                 input = Single[FitNode],
                 output = DataNode
+            ),
+            NodeAnnotation(
+                label="Callback",
+                node_type= CallbackNode,
+                logic = CallbackNode.get_callback,
+                annotations = {
+                        "callback": Parameter(AttrType.INPUT, AEnum[Callbacks]),
+                    },
+                input = False
             )
         ],
         "Utils": [

--- a/Src/Enums/__init__.py
+++ b/Src/Enums/__init__.py
@@ -9,3 +9,4 @@ from Src.Enums.dpg_types import DPGType
 from Src.Enums.metrics import Metrics
 from Src.Enums.themes import Themes
 from Src.Enums.datasets import Datasets
+from Src.Enums.callbacks import Callbacks

--- a/Src/Enums/callbacks.py
+++ b/Src/Enums/callbacks.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class Callbacks(Enum):
+    """
+    Enum для Callback'ов при обучении
+    """
+    EARLY_STOPPING = "EarlyStopping"
+    REDUCE_LRO_ON_PLATEAU = "ReduceLROnPlateau"

--- a/Src/Enums/callbacks.py
+++ b/Src/Enums/callbacks.py
@@ -3,7 +3,9 @@ from enum import Enum
 
 class Callbacks(Enum):
     """
-    Enum для Callback'ов при обучении
+    Enum для callback'ов при обучении
     """
     EARLY_STOPPING = "EarlyStopping"
     REDUCE_LRO_ON_PLATEAU = "ReduceLROnPlateau"
+    TERMINATE_ON_NAN = "TerminateOnNaN"
+    LOG2WINDOW = "Log2Window"

--- a/Src/Enums/themes.py
+++ b/Src/Enums/themes.py
@@ -21,3 +21,4 @@ class Themes(StrEnum):
     TABLE_DATA = "table_data"
     IMAGE_DATA = "image_data"
     DATASET = 'dataset'
+    CALLBACK = 'callback'

--- a/Src/Nodes/__init__.py
+++ b/Src/Nodes/__init__.py
@@ -11,3 +11,4 @@ from Src.Nodes.metric_node import MetricNode
 from Src.Nodes.fit_node import FitNode
 from Src.Nodes.predict_node import PredictNode
 from Src.Nodes.dataset_node import DatasetNode
+from Src.Nodes.callback_node import CallbackNode

--- a/Src/Nodes/abstract_node.py
+++ b/Src/Nodes/abstract_node.py
@@ -80,7 +80,7 @@ class AbstractNode(ABC):
         '''
         Выводит сообщение в окно сборки модели.
         '''
-        dpg.add_text(message, parent="compile_window")
+        dpg.add_text(message, parent="current_node_messages")
 
 
     def compile(self, kwargs: dict = None) -> bool:
@@ -94,6 +94,7 @@ class AbstractNode(ABC):
         self.logger.info(f"Компиляция ноды - {self.__class__.__name__}")
         self.logger.debug(f"Аргументы ноды - {arguments}")
 
+        current_node_messages = dpg.add_group(tag="current_node_messages", parent="compile_window")
         AbstractNode.log2window(self.message)
 
         for argument in arguments:
@@ -131,6 +132,8 @@ class AbstractNode(ABC):
             self.raise_error(ex)
             return False
             
+        dpg.delete_item(current_node_messages)
+
         return True
 
 

--- a/Src/Nodes/abstract_node.py
+++ b/Src/Nodes/abstract_node.py
@@ -55,6 +55,7 @@ class AbstractNode(ABC):
         self.incoming = {}
         self.outgoing = {}
         self.OUTPUT = None
+        self.message = f"Сборка ноды {self}"
 
         if not docs: docs = inspect.getdoc(self.logic)
         self.docs = docs
@@ -75,21 +76,11 @@ class AbstractNode(ABC):
 
 
     @staticmethod
-    def add_message_to_compile_window_static(message: str):
+    def log2window(message: str):
         '''
         Выводит сообщение в окно сборки модели.
         '''
         dpg.add_text(message, parent="compile_window")
-
-
-    def add_message_to_compile_window(self, message: str = None):
-        '''
-        Выводит сообщение в окно сборки модели. По умолчанию выводится "Сборка ноды <__str__>".
-        '''
-        if message is not None:
-            AbstractNode.add_message_to_compile_window_static(message)
-        else:
-            AbstractNode.add_message_to_compile_window_static(f"Сборка ноды {self}")
 
 
     def compile(self, kwargs: dict = None) -> bool:
@@ -103,7 +94,7 @@ class AbstractNode(ABC):
         self.logger.info(f"Компиляция ноды - {self.__class__.__name__}")
         self.logger.debug(f"Аргументы ноды - {arguments}")
 
-        self.add_message_to_compile_window()
+        AbstractNode.log2window(self.message)
 
         for argument in arguments:
             name = dpg.get_item_label(argument)

--- a/Src/Nodes/abstract_node.py
+++ b/Src/Nodes/abstract_node.py
@@ -135,6 +135,14 @@ class AbstractNode(ABC):
             dpg.add_text(f"Сборка ноды {self}", parent="compile_window")
 
 
+    @staticmethod
+    def add_message_to_compile_window_static(message: str):
+        '''
+        Выводит сообщение в окно сборки модели.
+        '''
+        dpg.add_text(message, parent="compile_window")
+
+
     def raise_error(self, error_message: str, error_message_type: str = "Неизвестная ошибка"):
         ThemeManager.add_theme(self.node_tag,Themes.ERROR)
 

--- a/Src/Nodes/abstract_node.py
+++ b/Src/Nodes/abstract_node.py
@@ -85,6 +85,8 @@ class AbstractNode(ABC):
         self.logger.info(f"Компиляция ноды - {self.__class__.__name__}")
         self.logger.debug(f"Аргументы ноды - {arguments}")
 
+        self.add_message_to_compile_window()
+
         for argument in arguments:
             name = dpg.get_item_label(argument)
 
@@ -121,7 +123,17 @@ class AbstractNode(ABC):
             return False
             
         return True
-    
+
+
+    def add_message_to_compile_window(self, message: str = None):
+        '''
+        Выводит сообщение в окно сборки модели. По умолчанию выводится "Сборка ноды <__str__>".
+        '''
+        if message is not None:
+            dpg.add_text(message, parent="compile_window")
+        else:
+            dpg.add_text(f"Сборка ноды {self}", parent="compile_window")
+
 
     def raise_error(self, error_message: str, error_message_type: str = "Неизвестная ошибка"):
         ThemeManager.add_theme(self.node_tag,Themes.ERROR)

--- a/Src/Nodes/abstract_node.py
+++ b/Src/Nodes/abstract_node.py
@@ -74,6 +74,24 @@ class AbstractNode(ABC):
         return self.node_tag
 
 
+    @staticmethod
+    def add_message_to_compile_window_static(message: str):
+        '''
+        Выводит сообщение в окно сборки модели.
+        '''
+        dpg.add_text(message, parent="compile_window")
+
+
+    def add_message_to_compile_window(self, message: str = None):
+        '''
+        Выводит сообщение в окно сборки модели. По умолчанию выводится "Сборка ноды <__str__>".
+        '''
+        if message is not None:
+            dpg.add_text(message, parent="compile_window")
+        else:
+            dpg.add_text(f"Сборка ноды {self}", parent="compile_window")
+
+
     def compile(self, kwargs: dict = None) -> bool:
         '''
         Основной метод нодов, содержащий логику их работы. Тут создаются слои нейронной сети, проходит обучение и т.д. В зависимости от ноды, будет разная логика.
@@ -123,24 +141,6 @@ class AbstractNode(ABC):
             return False
             
         return True
-
-
-    def add_message_to_compile_window(self, message: str = None):
-        '''
-        Выводит сообщение в окно сборки модели. По умолчанию выводится "Сборка ноды <__str__>".
-        '''
-        if message is not None:
-            dpg.add_text(message, parent="compile_window")
-        else:
-            dpg.add_text(f"Сборка ноды {self}", parent="compile_window")
-
-
-    @staticmethod
-    def add_message_to_compile_window_static(message: str):
-        '''
-        Выводит сообщение в окно сборки модели.
-        '''
-        dpg.add_text(message, parent="compile_window")
 
 
     def raise_error(self, error_message: str, error_message_type: str = "Неизвестная ошибка"):

--- a/Src/Nodes/abstract_node.py
+++ b/Src/Nodes/abstract_node.py
@@ -87,9 +87,9 @@ class AbstractNode(ABC):
         Выводит сообщение в окно сборки модели. По умолчанию выводится "Сборка ноды <__str__>".
         '''
         if message is not None:
-            dpg.add_text(message, parent="compile_window")
+            AbstractNode.add_message_to_compile_window_static(message)
         else:
-            dpg.add_text(f"Сборка ноды {self}", parent="compile_window")
+            AbstractNode.add_message_to_compile_window_static(f"Сборка ноды {self}")
 
 
     def compile(self, kwargs: dict = None) -> bool:

--- a/Src/Nodes/callback_node.py
+++ b/Src/Nodes/callback_node.py
@@ -1,0 +1,18 @@
+from keras import callbacks
+
+from Src.Enums import Themes
+from Src.Nodes import AbstractNode
+
+
+
+class CallbackNode(AbstractNode):
+    theme_name: Themes = Themes.CALLBACK
+
+    callbacks_classes = {
+        "EarlyStopping": callbacks.EarlyStopping,
+        "ReduceLROnPlateau": callbacks.ReduceLROnPlateau
+    }
+
+    @staticmethod
+    def get_callback(*args, **kwargs):
+        return CallbackNode.callbacks_classes[kwargs["callback"]]()

--- a/Src/Nodes/callback_node.py
+++ b/Src/Nodes/callback_node.py
@@ -1,18 +1,20 @@
-from keras import callbacks
-
 from Src.Enums import Themes
 from Src.Nodes import AbstractNode
+from Src.Config.TrainingCallbacks import callbacks_list
 
 
 
 class CallbackNode(AbstractNode):
+    """
+    Нода для подключения callback'ов при обучении модели.
+    """
     theme_name: Themes = Themes.CALLBACK
 
-    callbacks_classes = {
-        "EarlyStopping": callbacks.EarlyStopping,
-        "ReduceLROnPlateau": callbacks.ReduceLROnPlateau
-    }
 
     @staticmethod
     def get_callback(*args, **kwargs):
-        return CallbackNode.callbacks_classes[kwargs["callback"]]()
+        """
+        Метод для получения callback'а и его параметров по его имени из словаря callback'ов.
+        """
+        callback = callbacks_list[kwargs["callback"]]
+        return callback["class"](**callback["kwargs"])

--- a/Src/Nodes/fit_node.py
+++ b/Src/Nodes/fit_node.py
@@ -36,8 +36,7 @@ class FitNode(DataNode):
         if kwargs['y'].dtype == np.object_ or np.isnan(kwargs['y']).any():
             raise AttributeError('Данные содержат неверный формат Y!')
         
-        trainingCallback = TrainingCallback()
-        history = model.fit(**kwargs, verbose=False, callbacks=[trainingCallback])
+        history = model.fit(**kwargs, verbose=False)
 
         return model
     

--- a/Src/Nodes/fit_node.py
+++ b/Src/Nodes/fit_node.py
@@ -49,28 +49,28 @@ class TrainingCallback(callbacks.Callback):
     Колбэк для вывода логов обучения в окно сборки модели.
     '''
 
-    def on_train_begin(self, logs=None):
+    def on_train_begin(self, logs: dict | None = None):
         '''
         Вывод в окно сборки модели сообщения о начале обучения.
         '''
         FitNode.add_message_to_compile_window_static("Обучение начато!")
 
 
-    def on_epoch_begin(self, epoch, logs=None):
+    def on_epoch_begin(self, epoch: int, logs: dict | None = None):
         '''
         Вывод в окно сборки модели сообщения о начале эпохи.
         '''
         FitNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} началась...")
 
 
-    def on_epoch_end(self, epoch, logs=None):
+    def on_epoch_end(self, epoch: int, logs: dict | None = None):
         '''
         Вывод в окно сборки модели сообщения о конце эпохи.
         '''
         FitNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} закончилась")
 
 
-    def on_train_end(self, logs=None):
+    def on_train_end(self, logs: dict | None = None):
         '''
         Вывод в окно сборки модели сообщения о конце обучения.
         '''

--- a/Src/Nodes/fit_node.py
+++ b/Src/Nodes/fit_node.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 import keras
 import dearpygui.dearpygui as dpg
 import numpy as np
-from tensorflow.keras import callbacks
 
 from Src.Enums import Themes
 from Src.Nodes import DataNode
@@ -39,38 +38,3 @@ class FitNode(DataNode):
         history = model.fit(**kwargs, verbose=False)
 
         return model
-    
-
-
-
-class TrainingCallback(callbacks.Callback):
-    '''
-    Колбэк для вывода логов обучения в окно сборки модели.
-    '''
-
-    def on_train_begin(self, logs: dict | None = None):
-        '''
-        Вывод в окно сборки модели сообщения о начале обучения.
-        '''
-        FitNode.add_message_to_compile_window_static("Обучение начато!")
-
-
-    def on_epoch_begin(self, epoch: int, logs: dict | None = None):
-        '''
-        Вывод в окно сборки модели сообщения о начале эпохи.
-        '''
-        FitNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} началась...")
-
-
-    def on_epoch_end(self, epoch: int, logs: dict | None = None):
-        '''
-        Вывод в окно сборки модели сообщения о конце эпохи.
-        '''
-        FitNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} закончилась")
-
-
-    def on_train_end(self, logs: dict | None = None):
-        '''
-        Вывод в окно сборки модели сообщения о конце обучения.
-        '''
-        FitNode.add_message_to_compile_window_static("Обучение завершено!")

--- a/Src/Nodes/fit_node.py
+++ b/Src/Nodes/fit_node.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import keras
 import dearpygui.dearpygui as dpg
 import numpy as np
+from tensorflow.keras import callbacks
 
 from Src.Enums import Themes
 from Src.Nodes import DataNode
@@ -35,9 +36,42 @@ class FitNode(DataNode):
         if kwargs['y'].dtype == np.object_ or np.isnan(kwargs['y']).any():
             raise AttributeError('Данные содержат неверный формат Y!')
         
-        history = model.fit(**kwargs, verbose=False)
+        trainingCallback = TrainingCallback()
+        history = model.fit(**kwargs, verbose=False, callbacks=[trainingCallback])
 
         return model
     
 
 
+
+class TrainingCallback(callbacks.Callback):
+    '''
+    Колбэк для вывода логов обучения в окно сборки модели.
+    '''
+
+    def on_train_begin(self, logs=None):
+        '''
+        Вывод в окно сборки модели сообщения о начале обучения.
+        '''
+        FitNode.add_message_to_compile_window_static("Обучение начато!")
+
+
+    def on_epoch_begin(self, epoch, logs=None):
+        '''
+        Вывод в окно сборки модели сообщения о начале эпохи.
+        '''
+        FitNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} началась...")
+
+
+    def on_epoch_end(self, epoch, logs=None):
+        '''
+        Вывод в окно сборки модели сообщения о конце эпохи.
+        '''
+        FitNode.add_message_to_compile_window_static(f"Эпоха {epoch + 1} закончилась")
+
+
+    def on_train_end(self, logs=None):
+        '''
+        Вывод в окно сборки модели сообщения о конце обучения.
+        '''
+        FitNode.add_message_to_compile_window_static("Обучение завершено!")

--- a/Src/Nodes/fit_node.py
+++ b/Src/Nodes/fit_node.py
@@ -34,13 +34,8 @@ class FitNode(DataNode):
         
         if kwargs['y'].dtype == np.object_ or np.isnan(kwargs['y']).any():
             raise AttributeError('Данные содержат неверный формат Y!')
-
-        with dpg.window(label="Обучение", modal=True, no_close=True,tag="fit_window") as popup:
-            dpg.add_loading_indicator(width=100, height=100)
         
         history = model.fit(**kwargs, verbose=False)
-
-        dpg.delete_item(popup)
 
         return model
     

--- a/Src/node_builder.py
+++ b/Src/node_builder.py
@@ -139,6 +139,9 @@ class NodeBuilder:
         self.logger.info("Началась сборка графа.")
         status = True
 
+        with dpg.window(label="Сборка модели", width=800, height=500, modal=True, no_close=True, tag="compile_window") as popup:
+            dpg.add_loading_indicator(width=100, height=100)
+
         while queue:
             self.logger.debug(f"Текущая очередь - {queue}")
             current_node = queue.pop(0)
@@ -166,6 +169,8 @@ class NodeBuilder:
 
                 visited.add(current_node)
 
+        dpg.delete_item(popup)
+        
         return visited
     
 


### PR DESCRIPTION
Перенёс создание окна из fit у FitNode в compile_graph у NodeBuilder. Модальность окна и невозможность его закрыть не менял. 

Добавил в AbstractNode методы для вывода в это окно: обычный и статический (add_message_to_compile_window и add_message_to_compile_window_static соответственно).
Статический метод нужен для использования в статических методах которые присваиваются нодам через logic.

Создал колбэк TrainingCallback унаследованный от callbacks.Callback из Keras, для вывода в окно логов о ходе обучения на каждой эпохе. Так как модель обучается внутри статического метода fit, колбэк использует статическую версию метода вывода на окно.