### PR TITLE
#152 Done Add GitHub Actions CI with session-scoped DPG context to pr

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y xvfb libgl1 libglib2.0-0 libglx-mesa0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: xvfb-run -a uv run --with pytest pytest

--- a/Tests/DPG_test.py
+++ b/Tests/DPG_test.py
@@ -21,8 +21,8 @@ class DPGUnitTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for item in list(dpg.get_all_items()):
-            try:
+            if dpg.get_item_parent(item) == 0:
                 dpg.delete_item(item)
-            except Exception:
-                pass
+        ThemeManager._created_themes = {}
+        ThemeManager._item_themes = {}
         return super().tearDownClass()

--- a/Tests/DPG_test.py
+++ b/Tests/DPG_test.py
@@ -7,12 +7,12 @@ from Src.Managers.theme_manager import ThemeManager
 
 class DPGUnitTest(unittest.TestCase):
     '''
-    Класс реализующий создание контекста и его разрушение, для тестирование элементов DPG
+    Базовый класс для тестов с DPG-контекстом.
+    Контекст создаётся один раз на всю сессию через conftest.py.
     '''
 
     @classmethod
     def setUpClass(cls):
-        cls.context = dpg.create_context()
         cls.parent = "Tests"
         cls.window = dpg.add_window(tag=cls.parent)
         ThemeManager.load_themes("Tests/themes.json")
@@ -20,5 +20,9 @@ class DPGUnitTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        dpg.destroy_context()
+        for item in list(dpg.get_all_items()):
+            try:
+                dpg.delete_item(item)
+            except Exception:
+                pass
         return super().tearDownClass()

--- a/Tests/conftest.py
+++ b/Tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+import dearpygui.dearpygui as dpg
+
+
+@pytest.fixture(scope="session", autouse=True)
+def dpg_session():
+    dpg.create_context()
+    dpg.create_viewport(title='Test Session')
+    dpg.setup_dearpygui()
+    yield

--- a/Tests/test_compilation.py
+++ b/Tests/test_compilation.py
@@ -20,7 +20,6 @@ class test_compilation(DPGUnitTestWithReset):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        dpg.create_viewport(title='Custom Title')
         with open("Tests/logger_config.json") as f:
             config = json.load(f)
 

--- a/Tests/test_node_builder.py
+++ b/Tests/test_node_builder.py
@@ -17,7 +17,6 @@ class test_NodeBuilder(DPGUnitTestWithReset):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        dpg.create_viewport(title='Custom Title')
         # Перезагружаем темы явно — после пересоздания контекста
         # старые ID тем из предыдущего тестового класса становятся невалидны
         ThemeManager.load_themes("Tests/themes.json")

--- a/Tests/test_node_editor.py
+++ b/Tests/test_node_editor.py
@@ -8,6 +8,7 @@ from Src.Config.Annotations import ANode
 from Src.Nodes import AbstractNode
 from Src.Enums.attr_type import AttrType
 from Src.Logging.logger_factory import Logger_factory
+from Src.Managers.theme_manager import ThemeManager
 from Tests.DPG_test_with_reset import DPGUnitTestWithReset
 
 
@@ -23,10 +24,6 @@ class test_NodeEditor(DPGUnitTestWithReset):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        dpg.create_viewport(title='Custom Title')
-        # Перезагружаем темы явно — после пересоздания контекста
-        # старые ID тем из предыдущего тестового класса становятся невалидны
-        from Src.Managers.theme_manager import ThemeManager
         ThemeManager.load_themes("Tests/themes.json")
         with open("Tests/logger_config.json") as f:
             config = json.load(f)


### PR DESCRIPTION
## Изменения
- Добавлен `.github/workflows/tests.yml` - автозапуск `pytest` при создании PR в `main` и `develop`
- Добавлен `Tests/conftest.py` - единый DPG-контекст на всю тест-сессию вместо создания/уничтожения в каждом классе
- Убраны `create_viewport()` / `setup_dearpygui()` из `setUpClass` тестовых классов - теперь это делает `conftest.py`
- `DPG_test.tearDownClass` чистит все DPG-элементы через `get_all_items()` для изоляции между классами

`dpg.destroy_context()` падал с segfault на Linux (GitHub Actions + xvfb), если viewport был создан но event loop никогда не запускался. Решение - один контекст на сессию, `destroy_context()` не вызывается вообще.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Добавлена автоматизированная система тестирования через CI/CD pipeline.
  * Оптимизирована инфраструктура тестирования для повышения надежности и консистентности.
  * Улучшена управление жизненным циклом тестовых сессий.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->