### PR TITLE
#115 Draft: added serialization and deserialization methods for all ano…

### DIFF
--- a/Src/Config/Annotations/annotation.py
+++ b/Src/Config/Annotations/annotation.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Callable
+from typing import Callable, Any
 
 
 
@@ -29,3 +29,19 @@ class Annotation(ABC):
     @abstractmethod
     def set(input_id: str| int, value) -> bool: pass
     
+
+    @staticmethod
+    @abstractmethod
+    def serialize(input_id: str | int) -> Any:
+        """
+        Преобразует значение графического виджета в JSON формат.
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def deserialize(input_id: str | int, value: Any) -> bool:
+        """
+        Принимает JSON-совместимое значение и записывает его в графический виджет.
+        """
+        pass

--- a/Src/Config/Annotations/anot_bool.py
+++ b/Src/Config/Annotations/anot_bool.py
@@ -29,3 +29,13 @@ class ABoolean(Annotation):
         
         dpg.set_value(input_id, value)
         return True
+    
+
+    @staticmethod
+    def serialize(input_id: str | int):
+        return ABoolean.get(input_id)
+    
+
+    @staticmethod
+    def deserialize(input_id: str | int, value : bool) -> bool:
+        return ABoolean.set(input_id, value)

--- a/Src/Config/Annotations/anot_enum.py
+++ b/Src/Config/Annotations/anot_enum.py
@@ -64,3 +64,14 @@ class AEnum(Annotation):
 
         dpg.set_value(input_id, value.value)
         return True
+    
+
+    def serialize(self, input_id: int | str):
+        return self.get(input_id)
+    
+
+    def deserialize(self, input_id: int | str, value: str) -> bool:
+        for member in self.source:
+            if member.value == value:
+                return self.set(input_id, value)
+        return False

--- a/Src/Config/Annotations/anot_figure.py
+++ b/Src/Config/Annotations/anot_figure.py
@@ -87,3 +87,11 @@ class AFigure(Annotation):
 
     def set(self, input_id: int | str, fig: plt.Figure) -> bool:
         return self.static_set(input_id, fig, self.display)
+    
+
+    def serialize(self, input_id: int | str):
+        return None 
+    
+
+    def deserialize(self, input_id: int | str, value) -> bool:
+        return True

--- a/Src/Config/Annotations/anot_file.py
+++ b/Src/Config/Annotations/anot_file.py
@@ -45,3 +45,18 @@ class AFile(Annotation):
         
         dpg.set_item_user_data(input_id, value)
         return True
+
+
+    @staticmethod
+    def serialize(input_id: int | str):
+        paths = AFile.get(input_id)
+        if not paths:
+            return None
+        return [str(path) for path in paths]
+    
+    @staticmethod
+    def deserialize(input_id: int | str, value: str) -> bool:
+        if value is None:
+            return True
+        paths = [Path(p) for p in value]
+        return AFile.set(input_id, value)

--- a/Src/Config/Annotations/anot_float.py
+++ b/Src/Config/Annotations/anot_float.py
@@ -29,3 +29,13 @@ class AFloat(Annotation):
         
         dpg.set_value(input_id, value)
         return True
+    
+
+    @staticmethod
+    def serialize(input_id: int | str):
+        return AFloat.get(input_id)
+    
+
+    @staticmethod
+    def deserialize(input_id: int | str, value: float) -> bool:
+        return AFloat.set(input_id, value)

--- a/Src/Config/Annotations/anot_integer.py
+++ b/Src/Config/Annotations/anot_integer.py
@@ -29,3 +29,13 @@ class AInteger(Annotation):
         
         dpg.set_value(input_id, value)
         return True 
+    
+    
+    @staticmethod
+    def serialize(input_id: int | str):
+        return AInteger.get(input)
+    
+
+    @staticmethod
+    def deserialize(input_id: int | str, value: int) -> bool:
+        return AInteger.set(input_id, value)

--- a/Src/Config/Annotations/anot_node.py
+++ b/Src/Config/Annotations/anot_node.py
@@ -70,3 +70,11 @@ class ANode(Annotation):
 
     def set(self, input_id: str | int, value) -> bool:
         return False
+    
+
+    def serialize(self, input_id: str | int):
+        return None
+    
+
+    def deserialize(self, input_id: str | int, value) -> bool:
+        return True

--- a/Src/Config/Annotations/anot_sequence.py
+++ b/Src/Config/Annotations/anot_sequence.py
@@ -65,3 +65,12 @@ class ASequence(Annotation):
 
         return True
     
+
+    def serialize(self, input_id: int | str):
+        return self.get(input_id)
+    
+
+    def deserialize(self, input_id: int | str, value: list) -> bool:
+        if value is None:
+            return False
+        return self.set(input_id, value)

--- a/Src/Config/Annotations/anot_string.py
+++ b/Src/Config/Annotations/anot_string.py
@@ -29,3 +29,13 @@ class AString(Annotation):
         
         dpg.set_value(input_id, value)
         return True
+    
+
+    @staticmethod
+    def serialize(input_id: int | str):
+        return AString.get(input_id)
+    
+
+    @staticmethod
+    def deserialize(input_id: int | str, value: str) -> bool:
+        return AString.get(input_id, value)


### PR DESCRIPTION
# Draft:

### 📝 Описание изменений (What's new)
Для каждого типа аннотаций, добавил методы сериализации и десериализации. При этом, сохранив логику абстрактных методов. Для аннотации enum и file прописал методы, которые будут переводить их в формат, который будет понятен json(str). Для аннотации node и figure, поставил некие заглушки, потому что они не хранят локальных статических параметров, которые нужно записывать в файл конфигурации ноды. 

### 🧪 Как протестировать (How to test)
Пока что никак. Нужно сначала дописать  подключение сериализации на уровне Parameter, а так же Сериализация и десериализация на уровне узла AbstractNode. 