### PR TITLE
#153 Done Add coverage check to CI/CD for pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests & Coverage
 
 on:
   pull_request:
@@ -14,7 +14,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y xvfb libgl1 libglib2.0-0 libglx-mesa0
+          sudo apt-get install -y xvfb libgl1 libglib2.0-0 libglx-mesa0 libsndfile1
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -25,7 +25,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --dev
 
-      - name: Run tests
-        run: xvfb-run -a uv run --with pytest pytest
+      - name: Run tests with coverage
+        run: xvfb-run -a uv run coverage run --source=Src -m pytest Tests/ -v
+
+      - name: Coverage report
+        run: uv run coverage report -m --fail-under=80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,15 @@ dev = [
     "coverage>=7.14.2",
     "pytest>=9.1.1",
 ]
+
+[tool.coverage.run]
+source = ["Src"]
+omit = ["*/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 80
+exclude_also = [
+    "def __repr__",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]


### PR DESCRIPTION
### 📝 Описание изменений (What's new)
Добавлена автоматическая проверка coverage в CI/CD при pull request в `main`/`develop`. CI запускает тесты через `coverage run`, генерирует отчёт и падает с ошибкой, если coverage ниже 80%. Также добавлена конфигурация `[tool.coverage.*]` в `pyproject.toml` для локального использования.

### 🧪 Как протестировать (How to test)
- Локально: `coverage run --source=Src -m pytest Tests/` затем `coverage report --fail-under=80`
- В CI: workflow `Tests & Coverage` автоматически срабатывает при PR в `main` или `develop`

---
Закрывает - #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Тестирование**
  * Улучшена автоматическая проверка качества тестов с формированием отчётов о покрытии.
  * Добавлен минимальный порог покрытия 80%; сборка завершается с ошибкой при его недостижении.
  * Обновлена настройка окружения для более стабильного запуска тестов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->